### PR TITLE
fix dependency between aoc-statsd-emitter and aws-otel-collector

### DIFF
--- a/otel-task-definition.json
+++ b/otel-task-definition.json
@@ -102,6 +102,9 @@
         },
         "image": "public.ecr.aws/highspot/alpine/socat:latest",
         "essential": false,
+        "links": [
+          "aws-otel-collector"
+        ],        
         "name": "aoc-statsd-emitter",
         "entryPoint": [
           "/bin/sh",

--- a/otel-task-definition.json
+++ b/otel-task-definition.json
@@ -83,6 +83,13 @@
         "image": "public.ecr.aws/nginx/nginx:latest",
         "name": "nginx",
         "essential": false,
+        "portMappings": [
+          {
+            "containerPort": 80,
+            "hostPort": 8080,
+            "protocol": "tcp"
+          }
+        ],        
         "dependsOn": [
           {
             "containerName": "aws-otel-collector",


### PR DESCRIPTION
*Issue #, if available:* Fix issue where statsd-emitter can't find aws-otel-collector container

*Description of changes:*

just add docker link between the 2 containers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
