### PR TITLE
Region should use the environment variable.

### DIFF
--- a/external-task-definition-logs.json
+++ b/external-task-definition-logs.json
@@ -25,7 +25,7 @@
         "logDriver": "awslogs",
         "options": {
             "awslogs-group": "ecsanywhere-logs",
-            "awslogs-region": "us-east-1",
+            "awslogs-region": "$AWS_REGION",
             "awslogs-stream-prefix": "logs"
         }
       }


### PR DESCRIPTION
Hardcoding region is causing problems running this in other regions. PR for this change.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
